### PR TITLE
Do not decrement follower nextIndex below 1

### DIFF
--- a/toy-raft/raft/raft.go
+++ b/toy-raft/raft/raft.go
@@ -344,11 +344,16 @@ func (rn *RaftNodeImpl) processOneTransistionInternal(inactivityTimeout time.Dur
 			} else {
 				// NOTE: this only executes if log doesn't match
 
-				// guard:
-				if followerState.nextIndex == 1 {
-					panic(fmt.Sprintf("cannot decrement nextIndex for follower %s below 1", appendEntriesResponse.ResponderId))
+				// minimum next index is 1
+				if followerState.nextIndex > 1 {
+					followerState.nextIndex -= 1
 				}
-				followerState.nextIndex -= 1
+
+				// guard:
+				if followerState.nextIndex < 1 {
+					panic(fmt.Sprintf("nextIndex for follower %s is below 1", appendEntriesResponse.ResponderId))
+				}
+
 				// guard:
 				// BUG: this is being violated sometimes
 				if followerState.nextIndex <= followerState.matchIndex {


### PR DESCRIPTION
If the current leader receives a unsuccessful append entry, it will
decrement the nextIndex for a follower. However, non-leaders can reject
append entry requests due to an outdated term and if the nextIndex is
already 1 because the replica log is still empty, the leader will try to
decrement nextIndex below 1.

Reported by Antithesis
Run: cfd1ec4bf99273b57cd43d73d8b5216a-17-4
Session: bbe2acf6d61b18536998f059e394f2d9-17-4
